### PR TITLE
feat: add optional name parameter to node constructors

### DIFF
--- a/src/GroveGames.BehaviourTree/Nodes/BehaviourNode.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/BehaviourNode.cs
@@ -15,9 +15,9 @@ public abstract class BehaviourNode : INode
     public NodeState State => _nodeState;
     public string Name => _name;
 
-    public BehaviourNode()
+    public BehaviourNode(string? name = null)
     {
-        _name = GetType().Name;
+        _name = name ?? GetType().Name;
     }
 
     public virtual void SetParent(IParent parent)

--- a/src/GroveGames.BehaviourTree/Nodes/Composites/Composite.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Composites/Composite.cs
@@ -6,7 +6,7 @@ public abstract class Composite : BehaviourNode, IParent
 
     protected IReadOnlyList<INode> Children => _children;
 
-    public Composite()
+    public Composite(string? name = null) : base(name)
     {
         _children = [];
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Composites/Parallel.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Composites/Parallel.cs
@@ -4,7 +4,7 @@ public sealed class Parallel : Composite
 {
     private readonly ParallelPolicy _policy;
 
-    public Parallel(ParallelPolicy policy)
+    public Parallel(ParallelPolicy policy, string? name = null) : base(name)
     {
         _policy = policy;
     }
@@ -55,9 +55,9 @@ public sealed class Parallel : Composite
 
 public static partial class ParentExtensions
 {
-    public static IParent Parallel(this IParent parent, ParallelPolicy policy)
+    public static IParent Parallel(this IParent parent, ParallelPolicy policy, string? name = null)
     {
-        var parallel = new Parallel(policy);
+        var parallel = new Parallel(policy, name);
         parent.Attach(parallel);
         return parallel;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Composites/Selector.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Composites/Selector.cs
@@ -4,7 +4,7 @@ public sealed class Selector : Composite
 {
     private int _processingChildIndex;
 
-    public Selector()
+    public Selector(string? name = null) : base(name)
     {
         _processingChildIndex = 0;
     }
@@ -59,9 +59,9 @@ public sealed class Selector : Composite
 
 public static partial class ParentExtensions
 {
-    public static IParent Selector(this IParent parent)
+    public static IParent Selector(this IParent parent, string? name = null)
     {
-        var selector = new Selector();
+        var selector = new Selector(name);
         parent.Attach(selector);
         return selector;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Composites/Sequence.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Composites/Sequence.cs
@@ -4,7 +4,7 @@ public sealed class Sequence : Composite
 {
     private int _processingChildIndex;
 
-    public Sequence()
+    public Sequence(string? name = null) : base(name)
     {
         _processingChildIndex = 0;
     }
@@ -64,9 +64,9 @@ public sealed class Sequence : Composite
 
 public static partial class ParentExtensions
 {
-    public static IParent Sequence(this IParent parent)
+    public static IParent Sequence(this IParent parent, string? name = null)
     {
-        var sequence = new Sequence();
+        var sequence = new Sequence(name);
         parent.Attach(sequence);
         return sequence;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Abort.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Abort.cs
@@ -4,7 +4,7 @@ public class Abort : Decorator
 {
     private readonly Func<bool> _condition;
 
-    public Abort(Func<bool> condition)
+    public Abort(Func<bool> condition, string? name = null) : base(name)
     {
         _condition = condition;
     }
@@ -23,9 +23,9 @@ public class Abort : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Abort(this IParent parent, Func<bool> condition)
+    public static IParent Abort(this IParent parent, Func<bool> condition, string? name = null)
     {
-        var abort = new Abort(condition);
+        var abort = new Abort(condition, name);
         parent.Attach(abort);
         return abort;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Conditional.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Conditional.cs
@@ -4,7 +4,7 @@ public sealed class Conditional : Decorator
 {
     private readonly Func<bool> _condition;
 
-    public Conditional(Func<bool> condition)
+    public Conditional(Func<bool> condition, string? name = null) : base(name)
     {
         _condition = condition;
     }
@@ -17,9 +17,9 @@ public sealed class Conditional : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Conditional(this IParent parent, Func<bool> condition)
+    public static IParent Conditional(this IParent parent, Func<bool> condition, string? name = null)
     {
-        var conditional = new Conditional(condition);
+        var conditional = new Conditional(condition, name);
         parent.Attach(conditional);
         return conditional;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Cooldown.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Cooldown.cs
@@ -5,7 +5,7 @@ public sealed class Cooldown : Decorator
     private readonly float _waitTime;
     private float _remainingTime;
 
-    public Cooldown(float waitTime)
+    public Cooldown(float waitTime, string? name = null) : base(name)
     {
         _waitTime = waitTime;
         _remainingTime = 0;
@@ -40,9 +40,9 @@ public sealed class Cooldown : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Cooldown(this IParent parent, float waitTime)
+    public static IParent Cooldown(this IParent parent, float waitTime, string? name = null)
     {
-        var cooldown = new Cooldown(waitTime);
+        var cooldown = new Cooldown(waitTime, name);
         parent.Attach(cooldown);
         return cooldown;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Decorator.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Decorator.cs
@@ -4,7 +4,7 @@ public abstract class Decorator : BehaviourNode, IParent
 {
     private INode _child;
 
-    public Decorator()
+    public Decorator(string? name = null) : base(name)
     {
         _child = Empty;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Delayer.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Delayer.cs
@@ -5,7 +5,7 @@ public sealed class Delayer : Decorator
     private readonly float _waitTime;
     private float _interval;
 
-    public Delayer(float waitTime)
+    public Delayer(float waitTime, string? name = null) : base(name)
     {
         _waitTime = waitTime;
         _interval = 0f;
@@ -40,9 +40,9 @@ public sealed class Delayer : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Delayer(this IParent parent, float waitTime)
+    public static IParent Delayer(this IParent parent, float waitTime, string? name = null)
     {
-        var delayer = new Delayer(waitTime);
+        var delayer = new Delayer(waitTime, name);
         parent.Attach(delayer);
         return delayer;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Failer.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Failer.cs
@@ -2,6 +2,8 @@
 
 public sealed class Failer : Decorator
 {
+    public Failer(string? name = null) : base(name) { }
+
     public override NodeState Evaluate(float deltaTime)
     {
         var status = base.Evaluate(deltaTime);
@@ -12,9 +14,9 @@ public sealed class Failer : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Failer(this IParent parent)
+    public static IParent Failer(this IParent parent, string? name = null)
     {
-        var failer = new Failer();
+        var failer = new Failer(name);
         parent.Attach(failer);
         return failer;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Inverter.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Inverter.cs
@@ -2,6 +2,8 @@
 
 public sealed class Inverter : Decorator
 {
+    public Inverter(string? name = null) : base(name) { }
+
     public override NodeState Evaluate(float deltaTime)
     {
         var status = base.Evaluate(deltaTime);
@@ -18,9 +20,9 @@ public sealed class Inverter : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Inverter(this IParent parent)
+    public static IParent Inverter(this IParent parent, string? name = null)
     {
-        var inverter = new Inverter();
+        var inverter = new Inverter(name);
         parent.Attach(inverter);
         return inverter;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Repeater.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Repeater.cs
@@ -6,7 +6,7 @@ public sealed class Repeater : Decorator
     private readonly int _maxCount;
     private int _currentCount;
 
-    public Repeater(RepeatMode repeatMode, int maxCount = -1)
+    public Repeater(RepeatMode repeatMode, int maxCount = -1, string? name = null) : base(name)
     {
         _repeatMode = repeatMode;
         _maxCount = maxCount;
@@ -69,9 +69,9 @@ public sealed class Repeater : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Repeater(this IParent parent, RepeatMode repeatMode)
+    public static IParent Repeater(this IParent parent, RepeatMode repeatMode, string? name = null)
     {
-        var repeater = new Repeater(repeatMode);
+        var repeater = new Repeater(repeatMode, name: name);
         parent.Attach(repeater);
         return repeater;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Reset.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Reset.cs
@@ -4,7 +4,7 @@ public class Reset : Decorator
 {
     private readonly Func<bool> _condition;
 
-    public Reset(Func<bool> condition)
+    public Reset(Func<bool> condition, string? name = null) : base(name)
     {
         _condition = condition;
     }
@@ -23,9 +23,9 @@ public class Reset : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Reset(this IParent parent, Func<bool> condition)
+    public static IParent Reset(this IParent parent, Func<bool> condition, string? name = null)
     {
-        var reset = new Reset(condition);
+        var reset = new Reset(condition, name);
         parent.Attach(reset);
         return reset;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/Succeeder.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/Succeeder.cs
@@ -2,6 +2,8 @@
 
 public sealed class Succeeder : Decorator
 {
+    public Succeeder(string? name = null) : base(name) { }
+
     public override NodeState Evaluate(float deltaTime)
     {
         var status = base.Evaluate(deltaTime);
@@ -12,9 +14,9 @@ public sealed class Succeeder : Decorator
 
 public static partial class ParentExtensions
 {
-    public static IParent Succeeder(this IParent parent)
+    public static IParent Succeeder(this IParent parent, string? name = null)
     {
-        var succeeder = new Succeeder();
+        var succeeder = new Succeeder(name);
         parent.Attach(succeeder);
         return succeeder;
     }

--- a/src/GroveGames.BehaviourTree/Nodes/Decorators/SuccessOnce.cs
+++ b/src/GroveGames.BehaviourTree/Nodes/Decorators/SuccessOnce.cs
@@ -4,7 +4,7 @@ public class SuccessOnce : Decorator
 {
     private bool _hasSucceeded;
 
-    public SuccessOnce()
+    public SuccessOnce(string? name = null) : base(name)
     {
         _hasSucceeded = false;
     }

--- a/tests/GroveGames.BehaviourTree.Tests/Nodes/NodeTests.cs
+++ b/tests/GroveGames.BehaviourTree.Tests/Nodes/NodeTests.cs
@@ -42,6 +42,32 @@ public class NodeTests
 
     private sealed class TestNode : BehaviourNode
     {
+        public TestNode(string? name = null) : base(name) { }
+    }
+
+    [Fact]
+    public void Name_ShouldReturnTypeName_WhenNoNameProvided()
+    {
+        var node = new TestNode();
+
+        Assert.Equal(nameof(TestNode), node.Name);
+    }
+
+    [Fact]
+    public void Name_ShouldReturnCustomName_WhenNameProvidedInConstructor()
+    {
+        var node = new TestNode("MyNode");
+
+        Assert.Equal("MyNode", node.Name);
+    }
+
+    [Fact]
+    public void SetName_ShouldOverrideName()
+    {
+        var node = new TestNode();
+        node.SetName("UpdatedName");
+
+        Assert.Equal("UpdatedName", node.Name);
     }
 
     [Fact]


### PR DESCRIPTION
All BehaviourNode subclasses now accept an optional string? name parameter in their constructors, eliminating the need to call SetName() separately after instantiation. Factory extension methods updated accordingly. Includes tests for default name, custom constructor name, and SetName override.